### PR TITLE
Allow students to unregister from activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -8,8 +8,8 @@ for extracurricular activities at Mergington High School.
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
-import os
 from pathlib import Path
+import os
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -117,15 +117,11 @@ def unregister_from_activity(activity_name: str, email: str):
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
     activity = activities[activity_name]
 
     # Validate student is signed up
     if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
     # Remove student
     activity["participants"].remove(email)


### PR DESCRIPTION
This pull request adds a DELETE API endpoint (`/activities/{activity_name}/unregister?email=...`) to allow students to unregister themselves from activities. It includes error handling for non-existent activities and students not signed up for the activity.